### PR TITLE
Corrected REPL usage example: unclosed form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 /.lein-plugins/checksum
 *#
 /.nrepl-port
+/.lein-repl-history
+

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ This API is pretty simple, just have a look at the following code:
     nil
     user> (require ['de.bertschneider.clj-geoip.core :refer :all])
     nil
-    user> (def mls (multi-lookup-service)
+    user> (def mls (multi-lookup-service))
+    #'user/mls
     user> (pprint (lookup mls "87.152.91.74"))
     {:timezone "Europe/Berlin",
      :ip "87.152.91.74",


### PR DESCRIPTION
I tested the README example and have a correction to submit involving an unclosed s-expression. Also updated to gitignore Leiningen REPL history.