### PR TITLE
Fix spec validation errors of ns form

### DIFF
--- a/src/de/bertschneider/clj_geoip/core.clj
+++ b/src/de/bertschneider/clj_geoip/core.clj
@@ -1,6 +1,6 @@
 (ns de.bertschneider.clj-geoip.core
   "Thin Clojure layer on top of the GeoIP Java API."
-  (import [com.maxmind.geoip LookupService regionName timeZone]))
+  (:import [com.maxmind.geoip LookupService regionName timeZone]))
 
 ;; ------ Lookupable ------
 


### PR DESCRIPTION
Loading clj-geoip with clojure 1.9.0-alpha14 emits a spec `ns` form validation error. This fixes the errors.